### PR TITLE
Annotate debugging-related display tasks with "debug_display" verilator tag for HARP-based applications

### DIFF
--- a/grayscale-fifo-overflow/rtl/grayscale_requestor.sv
+++ b/grayscale-fifo-overflow/rtl/grayscale_requestor.sv
@@ -46,7 +46,7 @@ module grayscale_requestor
 
   always_ff@(posedge clk) begin
     if (~not_full && enq_en) begin
-      $error("grayscale_requestor: fifo overflow");
+      $error("grayscale_requestor: fifo overflow"); /* verilator tag debug_display */
     end
   end
 

--- a/reed-solomon-decoder-buffer-overwrite/rtl/reed_solomon_decoder_requestor.sv
+++ b/reed-solomon-decoder-buffer-overwrite/rtl/reed_solomon_decoder_requestor.sv
@@ -314,7 +314,7 @@ module reed_solomon_decoder_requestor
             ccip_c1_tx.valid <= 1'b0;
             /* How to add this assertion? */
             if (wr_ptr == 6'h0 && valid_in) begin
-              $error("requestor: write combining buffer overwrite");
+              $error("requestor: write combining buffer overwrite"); /* verilator tag debug_display */
             end
           end
         end

--- a/sha512-valid-uncleared/rtl/ccip_std_afu_wrapper.sv
+++ b/sha512-valid-uncleared/rtl/ccip_std_afu_wrapper.sv
@@ -92,7 +92,7 @@ module ccip_std_afu_wrapper
                     almfull_c0tx_valid_cnt <= almfull_c0tx_valid_cnt + 1;
                 end
                 if (almfull_c0tx_valid_cnt > 8) begin
-                    $error("more than 8 packets sent out during c0TxAlmFull");
+                    $error("more than 8 packets sent out during c0TxAlmFull") /*verilator tag debug_display*/;
                 end
             end
             else begin
@@ -104,7 +104,7 @@ module ccip_std_afu_wrapper
                     almfull_c1tx_valid_cnt <= almfull_c1tx_valid_cnt + 1;
                 end
                 if (almfull_c1tx_valid_cnt > 8) begin
-                    $error("more than 8 packets sent out during c1TxAlmFull");
+                    $error("more than 8 packets sent out during c1TxAlmFull") /*verilator tag debug_display*/;
                 end
             end
             else begin

--- a/sha512-valid-uncleared/rtl/sha512_csr.sv
+++ b/sha512-valid-uncleared/rtl/sha512_csr.sv
@@ -101,6 +101,7 @@ module sha512_csr
   always_ff @(posedge clk) begin
     if (hc_dsm_sel(rx_mmio_channel)) begin
       hc_dsm_base <= t_ccip_clAddr'(rx_mmio_channel.data) >> 6;
+      $display("[%0t], hc_dsm_base 0x%h, clAddr 0x%h", $time, hc_dsm_base, t_ccip_clAddr'(rx_mmio_channel.data)) /*verilator tag debug_display*/;
     end
   end
 

--- a/sidebuf-overflow-conflict/lib/BBB_vai_mux_nested/hw/rtl/vai_mgr.sv
+++ b/sidebuf-overflow-conflict/lib/BBB_vai_mux_nested/hw/rtl/vai_mgr.sv
@@ -307,7 +307,7 @@ module vai_mgr # (parameter NUM_SUB_AFUS=8)
                 if (c0tx_buf_cnt == TX_BUF_SIZE)
                 begin
                     mgr_c0tx_sidebuf_overflow <= 1;
-                    $error("c0tx side buffer overflow detected");
+                    $error("c0tx side buffer overflow detected"); /* verilator tag debug_display */
                 end
             end
             else if (~sRx.c0TxAlmFull && c0tx_buf_cnt != 0)
@@ -318,7 +318,7 @@ module vai_mgr # (parameter NUM_SUB_AFUS=8)
                 if (afu_TxPort.c0.valid)
                 begin
                     mgr_c0tx_conflict <= 1;
-                    $error("c0tx side buffer and afu packet conflict");
+                    $error("c0tx side buffer and afu packet conflict"); /* verilator tag debug_display */
                 end
             end
             else
@@ -334,7 +334,7 @@ module vai_mgr # (parameter NUM_SUB_AFUS=8)
                 if (c1tx_buf_cnt == TX_BUF_SIZE)
                 begin
                     mgr_c1tx_sidebuf_overflow <= 1;
-                    $error("c1tx side buffer overflow detected");
+                    $error("c1tx side buffer overflow detected"); /* verilator tag debug_display */
                 end
             end
             else if (~sRx.c1TxAlmFull && c1tx_buf_cnt != 0)
@@ -345,7 +345,7 @@ module vai_mgr # (parameter NUM_SUB_AFUS=8)
                 if (afu_TxPort.c1.valid)
                 begin
                     mgr_c1tx_conflict <= 1;
-                    $error("c1tx side buffer and afu packet conflict");
+                    $error("c1tx side buffer and afu packet conflict"); /* verilator tag debug_display */
                 end
             end
             else

--- a/sssp-fsm-error/rtl/sssp/app_afu.sv
+++ b/sssp-fsm-error/rtl/sssp/app_afu.sv
@@ -317,6 +317,7 @@ module sssp_app_top
                     end
                 end
                 MAIN_FSM_PROCESS_EDGE_EARLY_START: begin
+                    $display("[%0t] FSM_EDGE_EARLY_START vertices_received %d", $time, vertices_received) /*verilator tag debug_display*/;
                     if (vertices_received) begin
                         state <= MAIN_FSM_PROCESS_EDGE;
                     end
@@ -383,7 +384,7 @@ module sssp_app_top
     always_ff @(posedge clk)
     begin
         if (vertex_receive_cnt > vertex_need_cnt) begin
-            $error("received vertices exceeds needed vertices");
+            $error("received vertices exceeds needed vertices: %d received, %d needed", vertex_receive_cnt, vertex_need_cnt);
         end
     end
 
@@ -421,7 +422,6 @@ module sssp_app_top
             else if (fifo_c1tx_count <= 4) begin
                 dma_pause <= 0;
             end
-
             case (state)
                 MAIN_FSM_IDLE: begin
                     dma_start <= 0;
@@ -524,6 +524,8 @@ module sssp_app_top
                     /* configure vertex counters */
                     vertex_need_cnt <= 9'(desc.vertex_ncl);
                     if (prefetch_desc_received) begin
+                        if (dma_out_valid)
+                            $display("[%0t] READ_VERTEX vertex_receive_cnt %d+1", $time, vertex_receive_cnt) /*verilator tag debug_display*/;
                         vertex_receive_cnt <= vertex_receive_cnt + dma_out_valid;
                     end
 
@@ -561,6 +563,8 @@ module sssp_app_top
                     end
 
                     if (prefetch_desc_received) begin
+                        if (dma_out_valid)
+                            $display("[%0t] EDGE_EARLY_START vertex_receive_cnt %d+1", $time, vertex_receive_cnt) /*verilator tag debug_display*/;
                         vertex_receive_cnt <= vertex_receive_cnt + dma_out_valid;
                     end
                 end


### PR DESCRIPTION
We only want to pay the overhead of recording debugging-specific display tasks. Now we need to manually annotate that type of display tasks.


We only want to pay the overhead of recording debugging-specific display
tasks. Now we need to manually annotate that type of display tasks.