### PR TITLE
Add a shared "synth" make target to synthesize instrumented HARP-based applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*notask*
+*withtask*
+build*

--- a/common/Makefile.rules
+++ b/common/Makefile.rules
@@ -1,0 +1,22 @@
+VERIPASS_PATH?=${HOME}/FPGA/veripass
+SV2V?=${VERIPASS_PATH}/sv2v.py
+SV2V_OUT_MODES=notask withtask
+SV2V_SOURCES=$(foreach mode, ${SV2V_OUT_MODES}, sources.$(mode).txt)
+SV2V_SYNTH=$(foreach mode, ${SV2V_OUT_MODES}, build_${mode})
+SYNTH_AFU_JSON=../common/cci_afu.json
+SYNTH_CCIP_DEWRAPPER=../common/ccip_dewrapper.sv
+
+withtask.v: ${RTL_SOURCES}
+	${SV2V} --top ${TOP_MODULE} -F ${RTL_SOURCES} --tasksupport -o $@
+notask.v: ${RTL_SOURCES}
+	${SV2V} --top ${TOP_MODULE} -F ${RTL_SOURCES} -o $@
+.PHONY: clean_synth synth
+clean_synth:
+	rm -rf ${SV2V_SYNTH} ${SV2V_SOURCES} $(foreach s, ${SV2V_SYNTH}, $(s).log) withtask.v notask.v
+sources.%.txt: %.v
+	echo -e "${SYNTH_AFU_JSON}\n${SYNTH_CCIP_DEWRAPPER}\n$<" > $@
+build_%: sources.%.txt %.v
+	rm -rf $@
+	afu_synth_setup -s $< $@
+	cd $@ && run.sh > $@.log 2>&1
+synth: ${SV2V_SYNTH}

--- a/common/cci_afu.json
+++ b/common/cci_afu.json
@@ -1,0 +1,18 @@
+{
+   "version": 1,
+   "afu-image": {
+      "power": 0,
+      "afu-top-interface":
+         {
+            "name": "ccip_std_afu"
+         },
+      "accelerator-clusters":
+         [
+            {
+               "name": "cci_afu",
+               "total-contexts": 1,
+               "accelerator-type-uuid": "c6aa954a-9b91-4a77-abc1-1d9f0709dcc7"
+            }
+         ]
+   }
+}

--- a/grayscale-fifo-overflow/Makefile
+++ b/grayscale-fifo-overflow/Makefile
@@ -41,3 +41,5 @@ sim:
 
 wave:
 	gtkwave *.fst >/dev/null 2>/dev/null &
+
+include ../common/Makefile.rules

--- a/reed-solomon-decoder-buffer-overwrite/Makefile
+++ b/reed-solomon-decoder-buffer-overwrite/Makefile
@@ -1,5 +1,5 @@
-#RTL_SOURCES?=sources.txt
-RTL_SOURCES?=instrumented.txt
+RTL_SOURCES?=sources.txt
+#RTL_SOURCES?=instrumented.txt
 TOP_MODULE?=ccip_std_afu_wrapper
 RTL_WORK_DIR?=work
 TEST_DIR?=test
@@ -43,3 +43,5 @@ sim:
 
 wave:
 	gtkwave *.fst >/dev/null 2>/dev/null &
+
+include ../common/Makefile.rules

--- a/sha512-valid-uncleared/Makefile
+++ b/sha512-valid-uncleared/Makefile
@@ -44,3 +44,5 @@ sim:
 
 wave:
 	gtkwave *.fst >/dev/null 2>/dev/null &
+
+include ../common/Makefile.rules

--- a/sidebuf-overflow-conflict/Makefile
+++ b/sidebuf-overflow-conflict/Makefile
@@ -1,4 +1,5 @@
-RTL_SOURCES?=instrumented.txt
+RTL_SOURCES?=sources.txt
+#RTL_SOURCES?=instrumented.txt
 TOP_MODULE?=ccip_std_afu_wrapper
 RTL_WORK_DIR?=work
 TEST_DIR?=test
@@ -46,3 +47,5 @@ sim:
 wave:
 	gtkwave grayscale_mux8_bug1.fst > /dev/null 2>/dev/null &
 	gtkwave grayscale_mux8_bug2.fst > /dev/null 2>/dev/null &
+
+include ../common/Makefile.rules

--- a/sssp-fsm-error/Makefile
+++ b/sssp-fsm-error/Makefile
@@ -42,3 +42,5 @@ sim:
 
 wave:
 	gtkwave *.fst >/dev/null 2>/dev/null &
+
+include ../common/Makefile.rules


### PR DESCRIPTION
1. `make synth` will call sv2v.py to instrument verilog code.
2. `make synth -j` can run multiple synthesize job at the same time.