### PR TITLE
Synthesize the AXI-lite (after verilator) in vivado.

### DIFF
--- a/common/Makefile.rules
+++ b/common/Makefile.rules
@@ -5,9 +5,10 @@ SV2V_SOURCES=$(foreach mode, ${SV2V_OUT_MODES}, sources.$(mode).txt)
 SV2V_SYNTH=$(foreach mode, ${SV2V_OUT_MODES}, build_${mode})
 SYNTH_AFU_JSON=../common/cci_afu.json
 SYNTH_CCIP_DEWRAPPER=../common/ccip_dewrapper.sv
+WITHTASK_OPT?=--tasksupport
 
 withtask.v: ${RTL_SOURCES}
-	${SV2V} --top ${TOP_MODULE} -F ${RTL_SOURCES} --tasksupport -o $@
+	${SV2V} --top ${TOP_MODULE} -F ${RTL_SOURCES} ${WITHTASK_OPT} -o $@
 notask.v: ${RTL_SOURCES}
 	${SV2V} --top ${TOP_MODULE} -F ${RTL_SOURCES} -o $@
 .PHONY: clean_synth synth

--- a/xilinx-axi-lite-incomplete-implementation/.gitignore
+++ b/xilinx-axi-lite-incomplete-implementation/.gitignore
@@ -4,3 +4,4 @@ work/
 *.vcd
 *_test
 *_work
+*.tcl

--- a/xilinx-axi-lite-incomplete-implementation/Makefile
+++ b/xilinx-axi-lite-incomplete-implementation/Makefile
@@ -40,3 +40,9 @@ sim:
 wave:
 	gtkwave sources0_test.vcd >/dev/null 2>/dev/null &
 	gtkwave sources1_test.vcd >/dev/null 2>/dev/null &
+
+# for resouce-util synthesize
+RTL_SOURCES=sources.txt
+TOP_MODULE=xlnxdemo
+WITHTASK_OPT=--tasksupport --tasksupport-mode=ILA --tasksupport-ignoretag --reset="!S_AXI_ARESETN"
+include ../common/Makefile.rules

--- a/xilinx-axi-lite-incomplete-implementation/README.md
+++ b/xilinx-axi-lite-incomplete-implementation/README.md
@@ -1,1 +1,13 @@
 Source: https://zipcpu.com/formal/2018/12/28/axilite.html
+
+Vivado Synth report util (tcl):
+`report_utilization -hierarchical -file util_1.rpt`
+
+Vivado Synth instructions:
+1. Use sv2v.py to create notask.v and withtask.v (special options are listed in
+   the Makefile). Note that these are still systemverilog code (due to
+   `always_comb`) so they need a verilog wrapper to be synthesizable.
+2. Import the verilog wrapper file (`vivado_synth/xlnxdemo_wrapper.v`) as source
+   code to an opened project in vivado.
+3. Tweak the module and instance names so that there are two wrappers, each
+   contains one buggy AXI-lite slave (with and without display instrumentation)

--- a/xilinx-axi-lite-incomplete-implementation/sources.txt
+++ b/xilinx-axi-lite-incomplete-implementation/sources.txt
@@ -1,0 +1,3 @@
++define+FORMAL
+rtl/faxil_slave.v
+rtl/xlnxdemo.v

--- a/xilinx-axi-lite-incomplete-implementation/vivado_synth/xlnxdemo_wrapper.v
+++ b/xilinx-axi-lite-incomplete-implementation/vivado_synth/xlnxdemo_wrapper.v
@@ -1,0 +1,98 @@
+module xlnxdemo_wrapper (
+  S_AXI_ACLK,
+  S_AXI_ARESETN,
+  S_AXI_AWADDR,
+  S_AXI_AWPROT,
+  S_AXI_AWVALID,
+  S_AXI_AWREADY,
+  S_AXI_WDATA,
+  S_AXI_WSTRB,
+  S_AXI_WVALID,
+  S_AXI_WREADY,
+  S_AXI_BRESP,
+  S_AXI_BVALID,
+  S_AXI_BREADY,
+  S_AXI_ARADDR,
+  S_AXI_ARPROT,
+  S_AXI_ARVALID,
+  S_AXI_ARREADY,
+  S_AXI_RDATA,
+  S_AXI_RRESP,
+  S_AXI_RVALID,
+  S_AXI_RREADY
+);
+
+(* X_INTERFACE_PARAMETER = "XIL_INTERFACENAME S_AXI_ACLK, ASSOCIATED_BUSIF S_AXI, ASSOCIATED_RESET S_AXI_ARESETN, FREQ_HZ 83333333, FREQ_TOLERANCE_HZ 0, PHASE 0, CLK_DOMAIN design_1_mig_7series_0_0_ui_clk, INSERT_VIP 0" *)
+(* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 S_AXI_ACLK CLK" *)
+input wire S_AXI_ACLK;
+(* X_INTERFACE_PARAMETER = "XIL_INTERFACENAME S_AXI_ARESETN, POLARITY ACTIVE_LOW, INSERT_VIP 0" *)
+(* X_INTERFACE_INFO = "xilinx.com:signal:reset:1.0 S_AXI_ARESETN RST" *)
+input wire S_AXI_ARESETN;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI AWADDR" *)
+input wire [6 : 0] S_AXI_AWADDR;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI AWPROT" *)
+input wire [2 : 0] S_AXI_AWPROT;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI AWVALID" *)
+input wire S_AXI_AWVALID;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI AWREADY" *)
+output wire S_AXI_AWREADY;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI WDATA" *)
+input wire [31 : 0] S_AXI_WDATA;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI WSTRB" *)
+input wire [3 : 0] S_AXI_WSTRB;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI WVALID" *)
+input wire S_AXI_WVALID;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI WREADY" *)
+output wire S_AXI_WREADY;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI BRESP" *)
+output wire [1 : 0] S_AXI_BRESP;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI BVALID" *)
+output wire S_AXI_BVALID;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI BREADY" *)
+input wire S_AXI_BREADY;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI ARADDR" *)
+input wire [6 : 0] S_AXI_ARADDR;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI ARPROT" *)
+input wire [2 : 0] S_AXI_ARPROT;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI ARVALID" *)
+input wire S_AXI_ARVALID;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI ARREADY" *)
+output wire S_AXI_ARREADY;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI RDATA" *)
+output wire [31 : 0] S_AXI_RDATA;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI RRESP" *)
+output wire [1 : 0] S_AXI_RRESP;
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI RVALID" *)
+output wire S_AXI_RVALID;
+(* X_INTERFACE_PARAMETER = "XIL_INTERFACENAME S_AXI, DATA_WIDTH 32, PROTOCOL AXI4LITE, FREQ_HZ 83333333, ID_WIDTH 0, ADDR_WIDTH 7, AWUSER_WIDTH 0, ARUSER_WIDTH 0, WUSER_WIDTH 0, RUSER_WIDTH 0, BUSER_WIDTH 0, READ_WRITE_MODE READ_WRITE, HAS_BURST 0, HAS_LOCK 0, HAS_PROT 1, HAS_CACHE 0, HAS_QOS 0, HAS_REGION 0, HAS_WSTRB 1, HAS_BRESP 1, HAS_RRESP 1, SUPPORTS_NARROW_BURST 0, NUM_READ_OUTSTANDING 1, NUM_WRITE_OUTSTANDING 1, MAX_BURST_LENGTH 1, PHASE 0, CLK_DOMAIN design_1_mig_7series_0_0_ui_clk, NUM_READ_THREADS 1, NUM_WRITE_T\
+HREADS 1, RUSER_BITS_PER_BYTE 0, WUSER_BITS_PER_BYTE 0, INSERT_VIP 0" *)
+(* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 S_AXI RREADY" *)
+input wire S_AXI_RREADY;
+
+  xlnxdemo
+  //#( .C_S_AXI_DATA_WIDTH(32), .C_S_AXI_ADDR_WIDTH(7))
+  inst (
+    .S_AXI_ACLK(S_AXI_ACLK),
+    .S_AXI_ARESETN(S_AXI_ARESETN),
+    .S_AXI_AWADDR(S_AXI_AWADDR),
+    .S_AXI_AWPROT(S_AXI_AWPROT),
+    .S_AXI_AWVALID(S_AXI_AWVALID),
+    .S_AXI_AWREADY(S_AXI_AWREADY),
+    .S_AXI_WDATA(S_AXI_WDATA),
+    .S_AXI_WSTRB(S_AXI_WSTRB),
+    .S_AXI_WVALID(S_AXI_WVALID),
+    .S_AXI_WREADY(S_AXI_WREADY),
+    .S_AXI_BRESP(S_AXI_BRESP),
+    .S_AXI_BVALID(S_AXI_BVALID),
+    .S_AXI_BREADY(S_AXI_BREADY),
+    .S_AXI_ARADDR(S_AXI_ARADDR),
+    .S_AXI_ARPROT(S_AXI_ARPROT),
+    .S_AXI_ARVALID(S_AXI_ARVALID),
+    .S_AXI_ARREADY(S_AXI_ARREADY),
+    .S_AXI_RDATA(S_AXI_RDATA),
+    .S_AXI_RRESP(S_AXI_RRESP),
+    .S_AXI_RVALID(S_AXI_RVALID),
+    .S_AXI_RREADY(S_AXI_RREADY)
+  );
+endmodule
+


### PR DESCRIPTION
The options to call sv2v are configurable.
Refer to README.md for how to import generated code into vivado and
how to synthesize